### PR TITLE
Rename `L1GasUsed` to `GasForL1Cost`

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schema/types.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schema/types.ex
@@ -134,7 +134,7 @@ defmodule BlockScoutWeb.Schema.Types do
     field(:gas, :decimal)
     field(:gas_price, :wei)
     field(:gas_used, :decimal)
-    field(:l1_gas_used, :decimal)
+    field(:gas_for_l1_cost, :decimal)
     field(:index, :integer)
     field(:input, :string)
     field(:nonce, :nonce_hash)

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -440,14 +440,14 @@ end %>
             <dd class="col-sm-9 col-lg-10"> <%= gas_used(@transaction) %> <%= if gas_used_perc, do: "| #{gas_used_perc}%" %></dd>
           </dl>
 
-          <!-- L1 Gas Used by Transaction -->
+          <!-- Poster Fee -->
           <dl class="row">
             <dt class="col-sm-3 col-lg-2 text-muted">
               <%= render BlockScoutWeb.CommonComponentsView, "_i_tooltip_2.html",
                 text: gettext("Fee paid to the L1 aggregator for posting this transaction (contributes to L2 Gas Used).") %>
               <%= gettext "Poster Fee" %>
             </dt>
-            <dd class="col-sm-9 col-lg-10"> <%= format_wei_value(Explorer.Chain.Wei.mult(@transaction.gas_price, @transaction.l1_gas_used), :ether) %> </dd>
+            <dd class="col-sm-9 col-lg-10"> <%= format_wei_value(Explorer.Chain.Wei.mult(@transaction.gas_price, @transaction.gas_for_l1_cost), :ether) %> </dd>
           </dl>
 
           <!-- Nonce, Index in Block -->

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -98,7 +98,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "contractAddress" => "#{transaction.created_contract_address_hash}",
       "cumulativeGasUsed" => "#{transaction.cumulative_gas_used}",
       "gasUsed" => "#{transaction.gas_used}",
-      "l1GasUsed" => "#{transaction.l1_gas_used}"
+      "gasForL1Cost" => "#{transaction.gas_for_l1_cost}"
     }
   end
 
@@ -121,7 +121,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "contractAddress" => "#{transaction.created_contract_address_hash}",
       "cumulativeGasUsed" => "#{transaction.cumulative_gas_used}",
       "gasUsed" => "#{transaction.gas_used}",
-      "l1GasUsed" => "#{transaction.l1_gas_used}",
+      "gasForL1Cost" => "#{transaction.gas_for_l1_cost}",
       "confirmations" => "#{transaction.confirmations}"
     }
   end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -123,7 +123,7 @@ defmodule EthereumJSONRPC.Receipt do
         %{
           "cumulativeGasUsed" => cumulative_gas_used,
           "gasUsed" => gas_used,
-          "l1GasUsed" => l1_gas_used,
+          "gasForL1Cost" => gas_for_l1_cost,
           "contractAddress" => created_contract_address_hash,
           "transactionHash" => transaction_hash,
           "transactionIndex" => transaction_index
@@ -134,7 +134,7 @@ defmodule EthereumJSONRPC.Receipt do
     %{
       cumulative_gas_used: cumulative_gas_used,
       gas_used: gas_used,
-      l1_gas_used: l1_gas_used,
+      gas_for_l1_cost: gas_for_l1_cost,
       created_contract_address_hash: created_contract_address_hash,
       status: status,
       transaction_hash: transaction_hash,
@@ -259,7 +259,7 @@ defmodule EthereumJSONRPC.Receipt do
        do: {:ok, entry}
 
   defp entry_to_elixir({key, quantity})
-       when key in ~w(blockNumber cumulativeGasUsed gasUsed transactionIndex l1GasUsed) do
+       when key in ~w(blockNumber cumulativeGasUsed gasUsed transactionIndex gasForL1Cost) do
     result =
       if is_nil(quantity) do
         nil

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
@@ -55,7 +55,7 @@ defmodule EthereumJSONRPC.Transaction do
           block_number: non_neg_integer(),
           from_address_hash: EthereumJSONRPC.address(),
           gas: non_neg_integer(),
-          l1_gas_used: non_neg_integer(),
+          gas_for_l1_cost: non_neg_integer(),
           gas_price: non_neg_integer(),
           hash: EthereumJSONRPC.hash(),
           index: non_neg_integer(),

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -30,7 +30,7 @@ defmodule Explorer.Chain.Transaction do
   alias Explorer.Chain.Transaction.{Fork, Status}
 
   @optional_attrs ~w(max_priority_fee_per_gas max_fee_per_gas block_hash block_number created_contract_address_hash cumulative_gas_used earliest_processing_start
-                     error gas_used l1_gas_used index created_contract_code_indexed_at status to_address_hash revert_reason type has_error_in_internal_txs)a
+                     error gas_used gas_for_l1_cost index created_contract_code_indexed_at status to_address_hash revert_reason type has_error_in_internal_txs)a
 
   @required_attrs ~w(from_address_hash gas gas_price hash input nonce r s v value)a
 
@@ -152,7 +152,7 @@ defmodule Explorer.Chain.Transaction do
           gas: Gas.t(),
           gas_price: wei_per_gas,
           gas_used: Gas.t() | nil,
-          l1_gas_used: Gas.t() | nil,
+          gas_for_l1_cost: Gas.t() | nil,
           hash: Hash.t(),
           index: transaction_index | nil,
           input: Data.t(),
@@ -182,7 +182,7 @@ defmodule Explorer.Chain.Transaction do
              :gas,
              :gas_price,
              :gas_used,
-             :l1_gas_used,
+             :gas_for_l1_cost,
              :index,
              :created_contract_code_indexed_at,
              :input,
@@ -203,7 +203,7 @@ defmodule Explorer.Chain.Transaction do
              :gas,
              :gas_price,
              :gas_used,
-             :l1_gas_used,
+             :gas_for_l1_cost,
              :index,
              :created_contract_code_indexed_at,
              :input,
@@ -225,7 +225,7 @@ defmodule Explorer.Chain.Transaction do
     field(:gas, :decimal)
     field(:gas_price, Wei)
     field(:gas_used, :decimal)
-    field(:l1_gas_used, :decimal)
+    field(:gas_for_l1_cost, :decimal)
     field(:index, :integer)
     field(:created_contract_code_indexed_at, :utc_datetime_usec)
     field(:input, Data)

--- a/apps/explorer/priv/repo/migrations/20180117221923_create_transactions.exs
+++ b/apps/explorer/priv/repo/migrations/20180117221923_create_transactions.exs
@@ -14,7 +14,7 @@ defmodule Explorer.Repo.Migrations.CreateTransactions do
 
       # `null` when a pending transaction
       add(:gas_used, :numeric, precision: 100, null: true)
-      add(:l1_gas_used, :numeric, precision: 100, null: false)
+      add(:gas_for_l1_cost, :numeric, precision: 100, null: false)
 
       add(:hash, :bytea, null: false, primary_key: true)
 


### PR DESCRIPTION
Supports the field name change in the receipt format