### PR TITLE
Extend Tracer Timeout

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -89,7 +89,7 @@ defmodule EthereumJSONRPC.Geth do
   @tracer File.read!(@tracer_path)
 
   defp debug_trace_transaction_request(%{id: id, hash_data: hash_data}) do
-    request(%{id: id, method: "debug_traceTransaction", params: [hash_data, %{tracer: @tracer}]})
+    request(%{id: id, method: "debug_traceTransaction", params: [hash_data, %{tracer: @tracer, timeout: "60s"}]})
   end
 
   defp debug_trace_transaction_responses_to_internal_transactions_params(


### PR DESCRIPTION
Uses a 60 second timeout rather than the default 5 second one for `debug_traceTransaction`