### PR TITLE
Extend token name from string to text type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#6038](https://github.com/blockscout/blockscout/pull/6038) - Extend token name from string to text type
 
 ### Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 - [#6038](https://github.com/blockscout/blockscout/pull/6038) - Extend token name from string to text type
+- [#5850](https://github.com/blockscout/blockscout/pull/5850) - Fix too large postgres notifications
+
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain/events/db_sender.ex
+++ b/apps/explorer/lib/explorer/chain/events/db_sender.ex
@@ -3,6 +3,7 @@ defmodule Explorer.Chain.Events.DBSender do
   Sends events to Postgres.
   """
   alias Explorer.Repo
+  alias Explorer.Utility.EventNotification
 
   def send_data(event_type) do
     payload = encode_payload({:chain_event, event_type})
@@ -11,7 +12,10 @@ defmodule Explorer.Chain.Events.DBSender do
 
   def send_data(event_type, broadcast_type, event_data) do
     payload = encode_payload({:chain_event, event_type, broadcast_type, event_data})
-    send_notify(payload)
+
+    with {:ok, %{id: event_notification_id}} <- save_event_notification(payload) do
+      send_notify(to_string(event_notification_id))
+    end
   end
 
   defp encode_payload(payload) do
@@ -22,5 +26,11 @@ defmodule Explorer.Chain.Events.DBSender do
 
   defp send_notify(payload) do
     Repo.query!("select pg_notify('chain_event', $1::text);", [payload])
+  end
+
+  defp save_event_notification(event_data) do
+    event_data
+    |> EventNotification.new_changeset()
+    |> Repo.insert()
   end
 end

--- a/apps/explorer/lib/explorer/utility/event_notification.ex
+++ b/apps/explorer/lib/explorer/utility/event_notification.ex
@@ -1,0 +1,20 @@
+defmodule Explorer.Utility.EventNotification do
+  @moduledoc """
+  An auxiliary schema for sending postgres notifications.
+  """
+
+  use Explorer.Schema
+
+  schema "event_notifications" do
+    field(:data, :string)
+  end
+
+  @doc false
+  def changeset(event_notification, params \\ %{}) do
+    cast(event_notification, params, [:data])
+  end
+
+  def new_changeset(data) do
+    changeset(%__MODULE__{}, %{data: data})
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20220804114005_create_event_notifications.exs
+++ b/apps/explorer/priv/repo/migrations/20220804114005_create_event_notifications.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.CreateEventNotifications do
+  use Ecto.Migration
+
+  def change do
+    create table(:event_notifications) do
+      add(:data, :text, null: false)
+    end
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20220902083436_extend_token_name_type.exs
+++ b/apps/explorer/priv/repo/migrations/20220902083436_extend_token_name_type.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.ExtendTokenNameType do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tokens) do
+      modify(:name, :text, null: true)
+    end
+  end
+end


### PR DESCRIPTION
Implements upstream PRs to extend token name field and fix postgres notification errors

https://github.com/blockscout/blockscout/pull/6038
https://github.com/blockscout/blockscout/pull/5850

